### PR TITLE
Indicate that parser.javascript.url: true is necessary for wasm load

### DIFF
--- a/custom-webpack.config.js
+++ b/custom-webpack.config.js
@@ -20,7 +20,7 @@ const config = {
                 type: 'asset/resource'
             }
         ],
-        // this fixes the ttf url loading issue
+        // this is required for loading .wasm (and other) files. For context, see https://stackoverflow.com/a/75252098 and https://github.com/angular/angular-cli/issues/24617
         parser: {
             javascript: {
                 url: true


### PR DESCRIPTION
Fixes https://github.com/TypeFox/monaco-languageclient-ng-example/issues/3